### PR TITLE
Changed human readable description to conform with inbuilt descriptions

### DIFF
--- a/Editor/src/hu/racz/zalan/editor/file/GlslDataObject.java
+++ b/Editor/src/hu/racz/zalan/editor/file/GlslDataObject.java
@@ -8,7 +8,7 @@ import org.openide.util.NbBundle.Messages;
 import static hu.racz.zalan.editor.core.Constants.*;
 
 @Messages({
-    "LBL_Glsl_LOADER=Files of Glsl"
+    "LBL_Glsl_LOADER=GLSL Files"
 })
 @MIMEResolver.ExtensionRegistration(
         displayName = "#LBL_Glsl_LOADER",


### PR DESCRIPTION
Other file type display names have the word "file" on the end, so in lists of type files the desired type is easily found. The type this extension provides is oddly placed in lists of file types, and therefor hard to find, "GLSL" being the only type you cannot find alphabetically (under "G"). 

![image](https://user-images.githubusercontent.com/8028882/50982465-8a3c4d80-14fd-11e9-8fcd-8189792590c2.png)

This pull request simply changes the description so it conforms with others. Simple fix, would save me like 5 minutes of confusion :)